### PR TITLE
chore(.github/workflows/pr_validation): create `verify_windows_setup` job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        env:
-          GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
-          GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[all_extra]"

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -15,11 +15,35 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  verify_windows_setup:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ windows-2019 ]
+        python: [ "3.9" ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Do not checkout in the current working directory to ensure the further imported module is the installed one
+          path: anywhere
+      - name: Install miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: ${{ matrix.python }}
+          activate-environment: fedeca
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e "./anywhere/[all_extra]"
+      - name: Test import successful
+        run: |
+          python -c "import fedeca"
+          pip list
   run_tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ ubuntu-latest ]
         python: ["3.9"]
         # python: ["3.9", "3.10", "3.11"]  # TODO: expand to other pythons
     steps:
@@ -28,9 +52,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        env:
-          GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
-          GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[all_extra]"


### PR DESCRIPTION
# Issue

[Windows setup](https://owkin.slack.com/archives/C04SYLF6P27/p1701729090782139)

# Repro steps

Leveraging the `verify_windows_setup` job in https://github.com/owkin/fedeca/commit/5b0d4175649f06611bba3e7afc96974ec0ed5bc5 from initial commit (https://github.com/owkin/fedeca/commit/f636cdd21a881c79f7ba0e924ae6c62a7f61c177) raised an [error](https://github.com/owkin/fedeca/actions/runs/8201377669/job/22429960819?pr=19):
```txt
ERROR: Cannot install None, fedeca and fedeca[all-extra]==0.0.2 because these package versions have conflicting dependencies.

The conflict is caused by:
    fedeca 0.0.2 depends on pydantic<2.0
    fedeca[all-extra] 0.0.2 depends on pydantic<2.0
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
    substrafl 0.42.0 depends on pydantic<3.0 and >=2.3.0
```

# Disclaimer

This is not exactly the same error, but we have **no information** on the exact versions of `fedeca` and `substrafl` that were used when the issue was originally triggered.

# Current state

Dummy workflow successful (cf: [build](https://github.com/owkin/fedeca/actions/runs/8187338561/job/22387591357))

# Side notes

Unit test suite is not running on windows (cf: [build](https://github.com/owkin/fedeca/actions/runs/8186315301/job/22384474822))
