### PR TITLE
Test efficient federated ECA and pooled equivalence

### DIFF
--- a/fedeca/algorithms/torch_webdisco_algo.py
+++ b/fedeca/algorithms/torch_webdisco_algo.py
@@ -11,6 +11,7 @@ import torch
 from autograd import elementwise_grad
 from autograd import numpy as anp
 from lifelines.utils import StepSizer
+from pandas.api.types import is_numeric_dtype
 from scipy.linalg import norm
 from scipy.linalg import solve as spsolve
 from substrafl.algorithms.pytorch import weight_manager
@@ -603,6 +604,13 @@ class TorchWebDiscoAlgo(TorchAlgo):
         )
         y = y.to_numpy().astype("float64")
         data_from_opener = data_from_opener.drop(columns=["time_multiplier"])
+        # dangerous but we need to do it
+        string_columns = [
+            col
+            for col in data_from_opener.columns
+            if not (is_numeric_dtype(data_from_opener[col]))
+        ]
+        data_from_opener = data_from_opener.drop(columns=string_columns)
 
         # We drop the targets from X
         columns_to_drop = self._target_cols

--- a/fedeca/fedeca_core.py
+++ b/fedeca/fedeca_core.py
@@ -959,17 +959,21 @@ class FedECA(Experiment, BaseSurvivalEstimator, BootstrapMixin):
 
         else:
             # We directly estimate the variance matrix in the bootstrap case
+            # we drop the first run which is not bootstrapped
+            # bias=True to match the pooled implementation
             self.variance_matrix = np.cov(
-                self.final_params_array, rowvar=False
+                self.final_params_array[1:], rowvar=False, bias=True
             ).reshape(
                 (self.final_params_array.shape[1], self.final_params_array.shape[1])
             )
 
         # The final params vector is the params wo bootstrap
+        if self.final_params_array.ndim == 2 and self.final_params_array.shape[0] > 1:
+            final_params = self.final_params_array[0]
+        else:
+            final_params = self.final_params_array
 
-        summary = compute_summary_function(
-            np.mean(self.final_params_array, axis=0), self.variance_matrix, alpha
-        )
+        summary = compute_summary_function(final_params, self.variance_matrix, alpha)
 
         summary["exp(coef)"] = np.exp(summary["coef"])
         summary["exp(coef) lower 95%"] = np.exp(summary["coef lower 95%"])

--- a/fedeca/fedeca_core.py
+++ b/fedeca/fedeca_core.py
@@ -9,6 +9,7 @@ from typing import Optional, Union
 import numpy as np
 import pandas as pd
 import torch
+from pandas.api.types import is_numeric_dtype
 from scipy.linalg import inv
 from substra.sdk.models import ComputePlanStatus
 from substrafl.model_loading import download_algo_state
@@ -876,6 +877,9 @@ class FedECA(Experiment, BaseSurvivalEstimator, BootstrapMixin):
     def compute_propensity_scores(self, data: pd.DataFrame):
         """Compute propensity scores and corresponding weights."""
         X = data.drop([self.duration_col, self.event_col, self.treated_col], axis=1)
+        # dangerous but we need to do it
+        string_columns = [col for col in X.columns if not (is_numeric_dtype(X[col]))]
+        X = X.drop(columns=string_columns)
         Xprop = torch.from_numpy(np.array(X)).type(self.torch_dtype)
         with torch.no_grad():
             if hasattr(self, "propensity_model"):

--- a/fedeca/fedeca_core.py
+++ b/fedeca/fedeca_core.py
@@ -965,7 +965,7 @@ class FedECA(Experiment, BaseSurvivalEstimator, BootstrapMixin):
                 (self.final_params_array.shape[1], self.final_params_array.shape[1])
             )
 
-        # The final params vector is either the params wo bootstrap or the mean
+        # The final params vector is the params wo bootstrap
 
         summary = compute_summary_function(
             np.mean(self.final_params_array, axis=0), self.variance_matrix, alpha

--- a/fedeca/fedeca_core.py
+++ b/fedeca/fedeca_core.py
@@ -66,7 +66,7 @@ class FedECA(Experiment, BaseSurvivalEstimator, BootstrapMixin):
         ps_col="propensity_scores",
         num_rounds_list: list[int] = [10, 10],
         damping_factor_nr: float = 0.8,
-        l2_coeff_nr: float = 1e-6,
+        l2_coeff_nr: float = 0.0,
         standardize_data: bool = True,
         penalizer: float = 0.0,
         l1_ratio: float = 1.0,
@@ -119,7 +119,7 @@ class FedECA(Experiment, BaseSurvivalEstimator, BootstrapMixin):
         damping_factor_nr : float, optional
             Damping factor for natural gradient regularization, by default 0.8.
         l2_coeff_nr : float, optional
-            L2 regularization coefficient for natural gradient, by default 1e-6.
+            L2 regularization coefficient for natural gradient, by default 0.0.
         standardize_data : bool, optional
             Whether to standardize data before training, by default True.
         penalizer : float, optional

--- a/fedeca/fedeca_core.py
+++ b/fedeca/fedeca_core.py
@@ -968,7 +968,7 @@ class FedECA(Experiment, BaseSurvivalEstimator, BootstrapMixin):
             )
 
         # The final params vector is the params wo bootstrap
-        if self.final_params_array.ndim == 2 and self.final_params_array.shape[0] > 1:
+        if self.final_params_array.ndim == 2:
             final_params = self.final_params_array[0]
         else:
             final_params = self.final_params_array

--- a/fedeca/fedeca_core.py
+++ b/fedeca/fedeca_core.py
@@ -811,7 +811,7 @@ class FedECA(Experiment, BaseSurvivalEstimator, BootstrapMixin):
                 n_bootstrap=self.n_bootstrap,
                 bootstrap_seeds=self.bootstrap_seeds,
                 bootstrap_function=self.bootstrap_function,
-                bootstrap_specific_kwargs=[
+                client_specific_kwargs=[
                     {"propensity_model": model} for model in self.propensity_models
                 ],
             )[0]

--- a/fedeca/strategies/bootstraper.py
+++ b/fedeca/strategies/bootstraper.py
@@ -177,7 +177,7 @@ def make_bootstrap_strategy(
                     "client_specific_kwargs must have the same length as"
                     "bootstrap_seeds_list + 1"
                 )
-                self.bootstrap_specific_kwargs = client_specific_kwargs
+                self.client_specific_kwargs = client_specific_kwargs
                 self.kwargs.update({"client_specific_kwargs": client_specific_kwargs})
             else:
                 self.client_specific_kwargs = None
@@ -187,7 +187,7 @@ def make_bootstrap_strategy(
             # We add the first run wo bootstrapping
             for idx in range(len(self.seeds) + 1):
                 current_kwargs = copy.deepcopy(strategy.algo.kwargs)
-                if self.bootstrap_specific_kwargs is not None:
+                if self.client_specific_kwargs is not None:
                     current_kwargs.update(**self.client_specific_kwargs[idx])
                 self.individual_algos.append(
                     copy.deepcopy(strategy.algo.__class__(**current_kwargs))

--- a/fedeca/strategies/bootstraper.py
+++ b/fedeca/strategies/bootstraper.py
@@ -26,7 +26,7 @@ def make_bootstrap_strategy(
     n_bootstrap: Union[int, None] = None,
     bootstrap_seeds: Union[list[int], None] = None,
     bootstrap_function: Union[Callable, None] = None,
-    bootstrap_specific_kwargs: Union[None, list[dict]] = None,
+    client_specific_kwargs: Union[None, list[dict]] = None,
 ):
     """Bootstrap a substrafl strategy wo impacting the number of compute tasks.
 
@@ -57,7 +57,7 @@ def make_bootstrap_strategy(
         If None, use the BootstrapMixin function.
         Note that this can be used to provide splits/cross-validation capabilities
         as well where seed would be the fold number in a flattened list of folds.
-    bootstrap_specific_kwargs: Union[None, list[dict]]
+    client_specific_kwargs: Union[None, list[dict]]
         A list of dictionaries containing the kwargs to be passed to the algos
         if they are different for each bootstrap. It is useful to chain bootstrapped
         compute plans for instance.
@@ -170,26 +170,25 @@ def make_bootstrap_strategy(
 
     # We have to overwrite the original methods at the class level
     class BtstAlgo(strategy.algo.__class__):
-        def __init__(self, *args, bootstrap_specific_kwargs=None, **kwargs):
+        def __init__(self, *args, client_specific_kwargs=None, **kwargs):
             super().__init__(*args, **kwargs)
-            if bootstrap_specific_kwargs is not None:
-                assert len(bootstrap_seeds_list) == len(bootstrap_specific_kwargs), (
-                    "bootstrap_specific_kwargs must have the same length as"
-                    "bootstrap_seeds_list"
+            if client_specific_kwargs is not None:
+                assert len(bootstrap_seeds_list) == len(client_specific_kwargs), (
+                    "client_specific_kwargs must have the same length as"
+                    "bootstrap_seeds_list + 1"
                 )
-                self.bootstrap_specific_kwargs = bootstrap_specific_kwargs
-                self.kwargs.update(
-                    {"bootstrap_specific_kwargs": bootstrap_specific_kwargs}
-                )
+                self.bootstrap_specific_kwargs = client_specific_kwargs
+                self.kwargs.update({"client_specific_kwargs": client_specific_kwargs})
             else:
-                self.bootstrap_specific_kwargs = None
+                self.client_specific_kwargs = None
 
             self.seeds = bootstrap_seeds_list
             self.individual_algos = []
-            for idx in range(len(self.seeds)):
+            # We add the first run wo bootstrapping
+            for idx in range(len(self.seeds) + 1):
                 current_kwargs = copy.deepcopy(strategy.algo.kwargs)
                 if self.bootstrap_specific_kwargs is not None:
-                    current_kwargs.update(**self.bootstrap_specific_kwargs[idx])
+                    current_kwargs.update(**self.client_specific_kwargs[idx])
                 self.individual_algos.append(
                     copy.deepcopy(strategy.algo.__class__(**current_kwargs))
                 )
@@ -218,7 +217,10 @@ def make_bootstrap_strategy(
             with tempfile.TemporaryDirectory() as tmpdirname:
                 paths_to_checkpoints = []
                 for idx, algo in enumerate(self.individual_algos):
-                    path_to_checkpoint = Path(tmpdirname) / f"bootstrap_{idx}"
+                    if idx == 0:
+                        path_to_checkpoint = Path(tmpdirname) / "full_data"
+                    else:
+                        path_to_checkpoint = Path(tmpdirname) / f"bootstrap_{idx}"
                     algo.save_local_state(path_to_checkpoint)
                     paths_to_checkpoints.append(path_to_checkpoint)
 
@@ -248,9 +250,16 @@ def make_bootstrap_strategy(
             archive = zipfile.ZipFile(path, "r")
             with tempfile.TemporaryDirectory() as tmpdirname:
                 archive.extractall(tmpdirname)
+                full_data_checkpoints = [
+                    p for p in Path(tmpdirname).glob("**/full_data")
+                ]
+                assert len(full_data_checkpoints) == 1
+                full_data_checkpoint = full_data_checkpoints[0]
+
                 checkpoints_found = sorted(
                     [p for p in Path(tmpdirname).glob("**/bootstrap_*")]
                 )
+                checkpoints_found = [full_data_checkpoint] + checkpoints_found
                 self.checkpoints_list = [None] * len(checkpoints_found)
                 for idx, file in enumerate(checkpoints_found):
                     self.individual_algos[idx].load_local_state(file)
@@ -268,8 +277,8 @@ def make_bootstrap_strategy(
             return predictions
 
     btst_kwargs = copy.deepcopy(strategy.algo.kwargs)
-    if bootstrap_specific_kwargs is not None:
-        btst_kwargs.update({"bootstrap_specific_kwargs": bootstrap_specific_kwargs})
+    if client_specific_kwargs is not None:
+        btst_kwargs.update({"client_specific_kwargs": client_specific_kwargs})
     btst_algo = BtstAlgo(**btst_kwargs)
 
     class BtstStrategy(strategy.__class__):
@@ -277,7 +286,7 @@ def make_bootstrap_strategy(
             super().__init__(**kwargs)
             self.seeds = bootstrap_seeds_list
             self.individual_strategies = []
-            for _ in self.seeds:
+            for _ in [None] + self.seeds:
                 # We have to make sure they are independent and new
                 self.individual_strategies.append(copy.deepcopy(strategy))
             for local_name in local_functions_names["strategy"]:
@@ -377,15 +386,19 @@ def _bootstrap_local_function(
         """
         results = []
 
-        for idx, seed in enumerate(self.seeds):
-            bootstrapped_data = bootstrap_function(data=data_from_opener, seed=seed)
+        for idx, seed in enumerate([None] + self.seeds):
+            # On first run we don't bootstrap
+            if idx == 0:
+                data = data_from_opener
+            else:
+                data = bootstrap_function(data=data_from_opener, seed=seed)
             if shared_state is None:
                 res = getattr(getattr(self, individual_task_type)[idx], local_name)(
-                    data_from_opener=bootstrapped_data, _skip=True
+                    data_from_opener=data, _skip=True
                 )
             else:
                 res = getattr(getattr(self, individual_task_type)[idx], local_name)(
-                    data_from_opener=bootstrapped_data,
+                    data_from_opener=data,
                     shared_state=shared_state[idx],
                     _skip=True,
                 )

--- a/fedeca/strategies/bootstraper.py
+++ b/fedeca/strategies/bootstraper.py
@@ -173,9 +173,9 @@ def make_bootstrap_strategy(
         def __init__(self, *args, client_specific_kwargs=None, **kwargs):
             super().__init__(*args, **kwargs)
             if client_specific_kwargs is not None:
-                assert len(bootstrap_seeds_list) == len(client_specific_kwargs), (
+                assert (len(bootstrap_seeds_list) + 1) == len(client_specific_kwargs), (
                     "client_specific_kwargs must have the same length as"
-                    "bootstrap_seeds_list + 1"
+                    " bootstrap_seeds_list + 1"
                 )
                 self.client_specific_kwargs = client_specific_kwargs
                 self.kwargs.update({"client_specific_kwargs": client_specific_kwargs})

--- a/fedeca/tests/test_bootstraper.py
+++ b/fedeca/tests/test_bootstraper.py
@@ -329,8 +329,8 @@ def test_bootstrapping(strategy_params: dict, num_rounds: int):
         compute_plan_key=compute_plan.key,
         round_idx=strategy_params["get_true_nb_rounds"](num_rounds),
     )
-
-    bootstrapped_models_efficient = [alg._model for alg in algo.individual_algos]
+    # We don't care about the first model which is not bootstrapped
+    bootstrapped_models_efficient = [alg._model for alg in algo.individual_algos][1:]
 
     for model1, model2 in zip(bootstrapped_models_gt, bootstrapped_models_efficient):
         for p1, p2 in zip(model1.parameters(), model2.parameters()):
@@ -439,6 +439,7 @@ def test_bootstrapping_end2end():
     )
     print("Efficient bootstrap")
     fed_iptw.run()
-    beta_efficient = fed_iptw.final_params_array
+    # We don't care about the first run which is not bootstrapped
+    beta_efficient = fed_iptw.final_params_array.flatten()[1:]
 
     assert np.allclose(beta_inefficient.to_numpy(), beta_efficient.flatten())

--- a/fedeca/tests/test_fl_vs_pooled.py
+++ b/fedeca/tests/test_fl_vs_pooled.py
@@ -77,7 +77,7 @@ class TestFedECAEnd2End(TestTempDir):
             treated_col=cls._treated_col,
             duration_col=cls._duration_col,
             event_col=cls._event_col,
-            num_rounds_list=[50, 50],
+            num_rounds_list=[20, 20],
         )
 
         if variance_method == "bootstrap":
@@ -142,7 +142,7 @@ class TestBtstFedECAEnd2End(TestFedECAEnd2End):
     """BtstIPTW tests class."""
 
     @classmethod
-    def setUpClass(cls, seed=42, n_bootstrap=2):
+    def setUpClass(cls, seed=42, n_bootstrap=200):
         """Use parent class setup with robust=True."""
         bootstrap_seeds = []
         cls.n_bootstrap = n_bootstrap

--- a/fedeca/tests/test_fl_vs_pooled.py
+++ b/fedeca/tests/test_fl_vs_pooled.py
@@ -222,7 +222,3 @@ class TestBtstFedECAEnd2End(TestFedECAEnd2End):
             seed=42,
             bootstrap_function=bootstrap_function,
         )
-
-    def test_matching(self):
-        """Changing tolerance as we can't match precise seeds in bootstrap."""
-        super().test_matching(rtol=0.1)

--- a/fedeca/tests/test_fl_vs_pooled.py
+++ b/fedeca/tests/test_fl_vs_pooled.py
@@ -53,7 +53,7 @@ class TestFedECAEnd2End(TestTempDir):
         cls.variance_method = variance_method
         cls.ndim = ndim
         cls.bootstrap_seeds = bootstrap_seeds
-        cls.n_bootstrap = len(bootstrap_seeds)
+        cls.n_bootstrap = len(bootstrap_seeds) if bootstrap_seeds is not None else None
         data = CoxData(seed=cls.seed, n_samples=cls.nsamples, ndim=cls.ndim)
         df = data.generate_dataframe()
         cls.df = df.drop(columns=["propensity_scores"], axis=1)

--- a/fedeca/utils/data_utils.py
+++ b/fedeca/utils/data_utils.py
@@ -198,6 +198,7 @@ def split_dataframe_across_clients(
             df_path.unlink()
         cdf.to_csv(df_path, index=False)
         dfs.append(cdf)
+
     assets_directory = Path(fedeca.__file__).parent / "scripts" / "substra_assets"
 
     # Sample registration: will fill two dicts with relevant handles to retrieve

--- a/fedeca/utils/substrafl_utils.py
+++ b/fedeca/utils/substrafl_utils.py
@@ -11,6 +11,7 @@ import lifelines
 import numpy as np
 import pandas as pd
 import torch
+from pandas.api.types import is_numeric_dtype
 from sklearn.metrics import accuracy_score
 from substrafl.dependency import Dependency
 from substrafl.evaluation_strategy import EvaluationStrategy
@@ -390,7 +391,7 @@ def get_outmodel_function(
 
 
 class SubstraflTorchDataset(torch.utils.data.Dataset):
-    """Substra toch dataset class."""
+    """Substra torch dataset class."""
 
     def __init__(
         self,
@@ -425,7 +426,16 @@ class SubstraflTorchDataset(torch.utils.data.Dataset):
         self.is_inference = is_inference
         self.target_columns = target_columns
         self.columns_to_drop = list(set(columns_to_drop + self.target_columns))
-        self.x = self.data.drop(columns=self.columns_to_drop).to_numpy().astype(dtype)
+
+        string_columns = [
+            col for col in self.data.columns if not (is_numeric_dtype(self.data[col]))
+        ]
+        self.x = (
+            self.data.drop(columns=(self.columns_to_drop + string_columns))
+            .to_numpy()
+            .astype(dtype)
+        )
+
         self.y = self.data[self.target_columns].to_numpy().astype(dtype)
         self.return_torch_tensors = return_torch_tensors
 

--- a/fedeca/utils/survival_utils.py
+++ b/fedeca/utils/survival_utils.py
@@ -122,7 +122,8 @@ class BootstrapMixin(BootstrapMixinProtocol):
             data_resampled = self.bootstrap_sample(data, rng)
             return np.array(self.point_estimate(data_resampled))
 
-        std = np.std([bootstrap_coef() for _ in range(n_bootstrap)], axis=0)
+        final_params_array = [bootstrap_coef() for _ in range(n_bootstrap)]
+        std = np.std(final_params_array, axis=0)
         return std
 
 


### PR DESCRIPTION
This PR aims at establishing that the two methods give similar results by tracing the seeds and mimicking the sampling done in pooled in an FL setting.
For this purpose it introduces a bootstrap_function arg in FedECA allowing global-sampling emulation as well as adds a first training on non-bootstrapped data as a first run when bootstrapping a strategy.
