### PR TITLE
Fix cron-triggered CI mysteriously failing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         # build issues related to git not being installed
         "substrafl==0.46.0",
         "argparse",
-        "numpy",
+        "numpy==1.26.4",
         "pandas",
         "pre-commit",
         "scipy",


### PR DESCRIPTION
I suspect numpy got an update that is triggering this failure so I am fixing `numpy` version to 1.26.4 to be sure.